### PR TITLE
cabal: upd dep hspec -> <2.8

### DIFF
--- a/multistate.cabal
+++ b/multistate.cabal
@@ -107,7 +107,7 @@ test-suite multistate-test {
     multistate,
     base <999,
     transformers <0.6,
-    hspec >=2 && <2.6
+    hspec >=2 && <2.8
   ghc-options:      -Wall
   main-is:          Test.hs
   hs-source-dirs:   test


### PR DESCRIPTION
Resolves *Dependency boundary doesn`t allow project and its dependent projects to build in NixOS* https://github.com/lspitzner/multistate/issues/2

HSpec 2.6 -> 2.8 not changed much:
https://hackage.haskell.org/package/hspec/changelog

There was only one major change - they removed already deprecated module `Test.Hspec.Core`. Which seems like not used in your project.

Compiled, ran tests - tests go well.
Compiled under:
  - GHC: 8.6.4
  - Cabal: 2.4.1.0
  - Nix: 2.2